### PR TITLE
Update import library to support latest version of Django 2.2

### DIFF
--- a/jfu/templatetags/jfutags.py
+++ b/jfu/templatetags/jfutags.py
@@ -1,4 +1,4 @@
-from django.core.context_processors import csrf
+from django.middleware import csrf
 from django.urls import reverse
 from django.template import Library, Context, loader
 

--- a/jfu/templatetags/jfutags.py
+++ b/jfu/templatetags/jfutags.py
@@ -1,5 +1,5 @@
 from django.core.context_processors import csrf
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template import Library, Context, loader
 
 register = Library()


### PR DESCRIPTION
Django 2.0 and 2.2 removes the django.core.urlresolvers module, which was moved to django.urls in version 1.10. You should change any import to use django.urls instead, like this:

from django.urls import reverse
Note that Django 2.0 removes some features that previously were in django.core.urlresolvers, so you might have to make some more changes before your code works. See the features deprecated(https://docs.djangoproject.com/en/stable/releases/1.9/#features-deprecated-in-1-9) in 1.9 for details on those additional changes.